### PR TITLE
minimal dev container setup and explanation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+  "name": "Python 3",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/python:0-3.11",
+  "features": {
+    "ghcr.io/devcontainers-contrib/features/mkdocs:2": {
+      "plugins": "mkdocs-material mkdocs-roamlinks-plugin mkdocs-mermaid2-plugin"
+    }
+  },
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [8000]
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "pip3 install --user -r requirements.txt",
+
+  // Configure tool-specific properties.
+  // "customizations": {},
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # NTC Handbook
 
 This README should lay technical tasks like how to build the handbook frontend locally. This README is not part of the handbook, it's part of the frontend build process.
+
+## Running mkdocs locally
+
+To develop against our public-facing handbook (everything in [/docs](./docs)), you will need docker and vscode installed, along with the dev containers extension for vscode. With docker running, run the dev containers 'rebuild and launch' command from VSCode to load the application in a containerized environment. From there you can start the application from the vscode shell with `mkdocs serve`.


### PR DESCRIPTION
After pushing https://github.com/dsa-ntc/handbook/compare/erik/mkdocs-setup?expand=1 I realized that the handbook had had several major merges since I started work on setting up mkdocs. There might be something useful in that but here I've split out only the part where I set up dev containers for local development. Documentation is very light and could use some improvement- not sure I did anything right, but it works for me.